### PR TITLE
Fix typo in chmod command under setup

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -50,7 +50,7 @@ It also depends on a MongoDB database which is launched with Docker Compose.
     # set ownership to map container user ID 1000
     chown 1000 users.json data database
     # set permissions
-    chmod 400 mkdir
+    chmod 400 users.json
     chmod 700 data database
     ```
 


### PR DESCRIPTION
I think you meant to put `chmod 400 users.json` instead of `chmod 400 mkdir` as a file called `mkdir` was never created.