### PR TITLE
Updated to work with meemo 1.13.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 ARG BASE_IMAGE=alpine
-ARG ALPINE_VERSION=3.10
+ARG ALPINE_VERSION=3.12
 
 FROM ${BASE_IMAGE}:${ALPINE_VERSION} AS builder
-ARG MEEMO_VERSION=v1.9.2
-RUN apk add -q --progress --update npm git python-dev build-base
+ARG MEEMO_VERSION=v1.13.0
+RUN apk add -q --progress --update npm git python3-dev build-base
 RUN git clone --branch ${MEEMO_VERSION} --single-branch --depth 1 https://github.com/nebulade/meemo.git /temp &> /dev/null
 RUN mkdir /meemo && \
     cd /temp && \
@@ -24,13 +24,13 @@ LABEL org.label-schema.schema-version="1.0.0-rc1" \
     org.label-schema.vcs-ref=$VCS_REF \
     org.label-schema.vcs-url="https://github.com/qdm12/meemo" \
     org.label-schema.url="https://github.com/qdm12/meemo" \
-    org.label-schema.vcs-description="Lightweight Meemo 1.9.2 server" \
+    org.label-schema.vcs-description="Lightweight Meemo 1.13.0 server" \
     org.label-schema.vcs-usage="https://github.com/qdm12/meemo/blob/master/README.md#setup" \
     org.label-schema.docker.cmd="docker-compose up -d" \
     org.label-schema.docker.cmd.devel="docker-compose up" \
     org.label-schema.docker.params="" \
     org.label-schema.version="" \
-    image-size="103MB" \
+    image-size="114MB" \
     ram-usage="70MB" \
     cpu-usage="Low"
 EXPOSE 3000/tcp
@@ -41,11 +41,10 @@ HEALTHCHECK --interval=3m --timeout=5s --start-period=20s --retries=1 \
     CMD [ "$(wget -qS -O /dev/null http://localhost:$PORT 2>&1 | grep -F HTTP | cut -d " " -f 4 | grep -o 200)" = "200"  ] || exit 1
 ENV PORT=3000 \
     BIND_ADDRESS=0.0.0.0 \
-    APP_ORIGIN=http://localhost \
-    MONGODB_URL=mongodb://mongodb:27017/meemo \
+    CLOUDRON_APP_ORIGIN=http://localhost \
+    CLOUDRON_MONGODB_URL=mongodb://mongodb:27017/meemo \
     ATTACHMENT_DIR=/data \
-    LOCAL_AUTH_FILE=/users.json \
+    CLOUDRON_LOCAL_AUTH_FILE=/users.json \
     NODE_ENV=production
 COPY --from=builder --chown=1000 /meemo/ /meemo/
 USER 1000
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,9 @@ services:
       - ./users.json:/users.json
       - ./data:/data
     environment:
-      - MONGODB_URL=mongodb://mongodb:27017/meemo
-      - APP_ORIGIN=http://localhost
+      - CLOUDRON_MONGODB_URL=mongodb://mongodb:27017/meemo
+      - CLOUDRON_APP_ORIGIN=http://localhost
+      - LOCAL_AUTH_FILE=/users.json
     ports:
       - 3000:3000/tcp
     depends_on:


### PR DESCRIPTION
After release 1.9.2 meemo changed some env variables, adding prefix CLOUDRON_ to them. This changes Dockerfile accordingly, as well as update it to work with alpine 3.12.

docker-compose.yml is also updated with new variables. Part of the code still relies on the old env variable LOCAL_AUTH_FILE so that one is explicitly set. CLOUDRON_LOCAL_AUTH_FILE should probably also be set, in case users wish to place users.json elsewhere.

Obviously compose requires a new image to work, readme should also be changed with new version and variable names.